### PR TITLE
Fixed inbox link for recent changes in gmail

### DIFF
--- a/chrome/lib/gmailr.js
+++ b/chrome/lib/gmailr.js
@@ -200,7 +200,7 @@
 //                  this.leftMenu = el.find('.no .nM .TK').first().closest('.nn');
 
                     // use the inbox link as an anchor
-                    var v = el.find('a[href$="#inbox"]');
+                    var v = el.find('a[href$="#inbox"][title^="Inbox"]');
                     if(v.length > 0) this.inboxLink = v.first();
 
                     var v = el.find('a[href$="#mbox"]');


### PR DESCRIPTION
Recent changes in gmail broke the bootstrap function because there is now another link ending in "#inbox" (the link in the Gmail logo).

Hoping that including the title would make this selector more specific.
